### PR TITLE
HTTP Range support on dataservice + CDN playback URL on metadataservice

### DIFF
--- a/dataservice/handlers/upload.go
+++ b/dataservice/handlers/upload.go
@@ -160,7 +160,7 @@ func (h *UploadHandler) Upload(w http.ResponseWriter, r *http.Request) {
 // @Failure      500  {string}  string  "Internal server error"
 // @Router       /videos/{id}/download [get]
 func (h *UploadHandler) Download(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
@@ -171,29 +171,55 @@ func (h *UploadHandler) Download(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userID := r.URL.Query().Get("user_id")
-	if userID == "" {
-		userID = r.Header.Get("X-User-ID")
-	}
-
-	sessionID := uuid.New().String()
-
-	// Publish watch.started event (best-effort)
-	h.publishWatchEvent(r, events.WatchStarted, videoID, userID, sessionID, 0)
-
-	// Download from S3
+	rangeHeader := r.Header.Get("Range")
 	key := "videos/" + videoID
-	body, err := h.storage.Download(r.Context(), key)
+
+	obj, err := h.storage.Download(r.Context(), key, rangeHeader)
 	if err != nil {
 		http.Error(w, "Failed to download file", http.StatusInternalServerError)
 		return
 	}
-	defer func() { _ = body.Close() }()
+	defer func() { _ = obj.Body.Close() }()
 
-	// Stream to client
-	w.Header().Set("Content-Type", "video/mp4")
-	w.Header().Set("Content-Disposition", "attachment; filename=video.mp4")
-	bytesWritten, err := io.Copy(w, body)
+	contentType := obj.ContentType
+	if contentType == "" {
+		contentType = "video/mp4"
+	}
+	w.Header().Set("Content-Type", contentType)
+	w.Header().Set("Accept-Ranges", "bytes")
+	w.Header().Set("Content-Disposition", "inline; filename=video.mp4")
+	if obj.ETag != "" {
+		w.Header().Set("ETag", obj.ETag)
+	}
+	if obj.ContentLength > 0 {
+		w.Header().Set("Content-Length", strconv.FormatInt(obj.ContentLength, 10))
+	}
+
+	status := http.StatusOK
+	if obj.ContentRange != "" {
+		w.Header().Set("Content-Range", obj.ContentRange)
+		status = http.StatusPartialContent
+	}
+
+	// Watch events are only meaningful for a full-object playback request.
+	// Partial (Range) requests come from player scrubbing/buffering; those
+	// clients are expected to report watch telemetry themselves.
+	isFull := rangeHeader == ""
+	userID := r.URL.Query().Get("user_id")
+	if userID == "" {
+		userID = r.Header.Get("X-User-ID")
+	}
+	sessionID := uuid.New().String()
+	if isFull {
+		h.publishWatchEvent(r, events.WatchStarted, videoID, userID, sessionID, 0)
+	}
+
+	w.WriteHeader(status)
+	if r.Method == http.MethodHead {
+		return
+	}
+
+	bytesWritten, err := io.Copy(w, obj.Body)
 	if err != nil {
 		// Cannot write HTTP error after partial response
 		if h.logger != nil {
@@ -202,8 +228,9 @@ func (h *UploadHandler) Download(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Publish watch.completed event (best-effort)
-	h.publishWatchEvent(r, events.WatchCompleted, videoID, userID, sessionID, bytesWritten)
+	if isFull {
+		h.publishWatchEvent(r, events.WatchCompleted, videoID, userID, sessionID, bytesWritten)
+	}
 }
 
 // publishWatchEvent publishes a watch event to Kafka (best-effort: logs errors, never fails the request).
@@ -300,17 +327,17 @@ func (h *UploadHandler) CompleteUpload(w http.ResponseWriter, r *http.Request) {
 	var merged bytes.Buffer
 	for i := 0; i < progress.UploadedChunks; i++ {
 		chunkKey := fmt.Sprintf("videos/%s/chunk_%d", progress.VideoID, i)
-		body, err := h.storage.Download(r.Context(), chunkKey)
+		obj, err := h.storage.Download(r.Context(), chunkKey, "")
 		if err != nil {
 			http.Error(w, fmt.Sprintf("Failed to read chunk %d", i), http.StatusInternalServerError)
 			return
 		}
-		if _, err := io.Copy(&merged, body); err != nil {
-			_ = body.Close()
+		if _, err := io.Copy(&merged, obj.Body); err != nil {
+			_ = obj.Body.Close()
 			http.Error(w, fmt.Sprintf("Failed to copy chunk %d", i), http.StatusInternalServerError)
 			return
 		}
-		_ = body.Close()
+		_ = obj.Body.Close()
 	}
 
 	// Upload merged file

--- a/dataservice/storage/s3.go
+++ b/dataservice/storage/s3.go
@@ -15,6 +15,16 @@ type S3Client struct {
 	bucket string
 }
 
+// Object is the result of a Download.
+// ContentRange is non-empty when the response is a partial (HTTP 206) result.
+type Object struct {
+	Body          io.ReadCloser
+	ContentLength int64
+	ContentType   string
+	ContentRange  string
+	ETag          string
+}
+
 func NewS3Client(ctx context.Context) (*S3Client, error) {
 	cfg, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
@@ -52,16 +62,33 @@ func (s *S3Client) Upload(ctx context.Context, key string, body io.Reader, size 
 	return err
 }
 
-// Download retrieves a file from S3
-func (s *S3Client) Download(ctx context.Context, key string) (io.ReadCloser, error) {
-	result, err := s.client.GetObject(ctx, &s3.GetObjectInput{
-		Bucket: &s.bucket,
-		Key:    &key,
-	})
+// Download retrieves a file (or byte range) from S3.
+// Pass an empty rangeHeader for a full download; otherwise pass an HTTP
+// Range header value (e.g. "bytes=0-1048575") which is forwarded to S3.
+// When S3 returns partial content, Object.ContentRange is populated.
+func (s *S3Client) Download(ctx context.Context, key, rangeHeader string) (*Object, error) {
+	in := &s3.GetObjectInput{Bucket: &s.bucket, Key: &key}
+	if rangeHeader != "" {
+		in.Range = &rangeHeader
+	}
+	result, err := s.client.GetObject(ctx, in)
 	if err != nil {
 		return nil, err
 	}
-	return result.Body, nil
+	obj := &Object{Body: result.Body}
+	if result.ContentLength != nil {
+		obj.ContentLength = *result.ContentLength
+	}
+	if result.ContentType != nil {
+		obj.ContentType = *result.ContentType
+	}
+	if result.ContentRange != nil {
+		obj.ContentRange = *result.ContentRange
+	}
+	if result.ETag != nil {
+		obj.ETag = *result.ETag
+	}
+	return obj, nil
 }
 
 // Delete removes an object from S3

--- a/metadataservice/handlers/video.go
+++ b/metadataservice/handlers/video.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/yourusername/videostreamingplatform/metadataservice/bl"
 	"github.com/yourusername/videostreamingplatform/metadataservice/models"
@@ -12,12 +13,25 @@ import (
 
 // VideoHandler handles HTTP requests for video operations
 type VideoHandler struct {
-	service *bl.VideoService
+	service    *bl.VideoService
+	cdnBaseURL string // e.g. https://d123.cloudfront.net; empty disables playback URL.
 }
 
-// NewVideoHandler creates a new video handler
-func NewVideoHandler(service *bl.VideoService) *VideoHandler {
-	return &VideoHandler{service: service}
+// NewVideoHandler creates a new video handler.
+// cdnBaseURL, when non-empty, is used to populate PlaybackURL on responses so
+// clients stream videos directly from the CDN.
+func NewVideoHandler(service *bl.VideoService, cdnBaseURL string) *VideoHandler {
+	return &VideoHandler{
+		service:    service,
+		cdnBaseURL: strings.TrimRight(cdnBaseURL, "/"),
+	}
+}
+
+func (h *VideoHandler) decorate(v *models.Video) {
+	if v == nil || h.cdnBaseURL == "" {
+		return
+	}
+	v.PlaybackURL = h.cdnBaseURL + "/videos/" + v.ID
 }
 
 // CreateVideo creates a new video metadata entry
@@ -44,6 +58,7 @@ func (h *VideoHandler) CreateVideo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	h.decorate(video)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 	_ = json.NewEncoder(w).Encode(video)
@@ -67,6 +82,7 @@ func (h *VideoHandler) GetVideo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	h.decorate(video)
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(video)
 }
@@ -98,6 +114,7 @@ func (h *VideoHandler) UpdateVideo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	h.decorate(video)
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(video)
 }
@@ -156,6 +173,9 @@ func (h *VideoHandler) ListVideos(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	for i := range videos {
+		h.decorate(videos[i])
+	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]interface{}{
 		"videos": videos,

--- a/metadataservice/main.go
+++ b/metadataservice/main.go
@@ -104,7 +104,10 @@ func main() {
 	videoService := bl.NewVideoService(repo, serviceOpts...)
 
 	// Initialize HTTP handlers
-	handler := handlers.NewVideoHandler(videoService)
+	handler := handlers.NewVideoHandler(videoService, cfg.CDNBaseURL)
+	if cfg.CDNBaseURL != "" {
+		logger.Printf("Playback URL decoration enabled → %s", cfg.CDNBaseURL)
+	}
 	recoClient := recommendations.NewClient(cfg.RecommendationServiceURL)
 	recoHandler := handlers.NewRecommendationHandler(recoClient)
 

--- a/metadataservice/models/video.go
+++ b/metadataservice/models/video.go
@@ -13,6 +13,9 @@ type Video struct {
 	UploadStatus   string    `json:"upload_status"`
 	CreatedAt      time.Time `json:"created_at"`
 	UpdatedAt      time.Time `json:"updated_at"`
+	// PlaybackURL is the viewer-facing URL for streaming this video. Populated
+	// by the handler from a CDN base URL; not persisted.
+	PlaybackURL string `json:"playback_url,omitempty"`
 }
 
 type Upload struct {

--- a/utils/config/config.go
+++ b/utils/config/config.go
@@ -67,6 +67,7 @@ type Config struct {
 
 	// CDN configuration
 	CDNDistributionID string // CloudFront distribution ID (empty = CDN invalidation disabled)
+	CDNBaseURL        string // CDN base URL for video downloads (e.g. https://d123.cloudfront.net). Empty = stream from origin.
 }
 
 // New creates a new Config instance from environment variables
@@ -104,6 +105,7 @@ func New(serviceName string) *Config {
 		RateLimitPerMin:          getEnvAsInt("RATE_LIMIT_PER_MIN", 60),    // 60 req/min default
 		RateLimitBurst:           getEnvAsInt("RATE_LIMIT_BURST", 100),     // burst of 100 default
 		CDNDistributionID:        getEnvOrDefault("CDN_DISTRIBUTION_ID", ""),
+		CDNBaseURL:               getEnvOrDefault("CDN_BASE_URL", ""),
 	}
 }
 


### PR DESCRIPTION
## Summary

- **dataservice/handlers**: `Download` now forwards the `Range` header to S3, returns `206 Partial Content` with `Accept-Ranges`/`Content-Range`, propagates `Content-Type`/`ETag`, and accepts `HEAD`. Enables player seeking and byte-range CDN caching. Watch events only fire on full-object requests.
- **dataservice/storage**: `S3Client.Download` takes an optional range string and returns a `*storage.Object` carrying the response metadata used by the handler.
- **metadataservice/handlers**: `VideoHandler` takes a `cdnBaseURL` and decorates responses with `playback_url: {CDN_BASE_URL}/videos/{id}`. Clients stream directly from CloudFront; dataservice is no longer in the viewer-path.
- **models.Video**: new `playback_url` (`omitempty`, not persisted).
- **utils/config**: new `CDN_BASE_URL` env var.

## Why this shape

The CDN-awareness lives in the metadata layer, not the byte-serving layer. `playback_url` is the seam where signing, multi-CDN steering, and HLS/DASH manifest generation will eventually plug in — which is what every major streaming platform does.

Set `CDN_BASE_URL=https://<cloudfront-domain>` on the metadataservice deployment to activate. Unset = local dev falls through to the dataservice origin endpoint (which now handles Range correctly).

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./dataservice/... ./metadataservice/... ./utils/config/...` passes
- [ ] Manual: `curl -H "Range: bytes=0-1023" /videos/{id}/download` returns 206 with `Content-Range`
- [ ] Manual: `GET /videos/{id}` on metadataservice with `CDN_BASE_URL` set returns `playback_url`
- [ ] Manual: `GET /videos/{id}` without `CDN_BASE_URL` omits `playback_url`

🤖 Generated with [Claude Code](https://claude.com/claude-code)