### PR TITLE
Map metadata-service handler errors to correct HTTP status codes

### DIFF
--- a/metadataservice/dl/video_repository.go
+++ b/metadataservice/dl/video_repository.go
@@ -3,12 +3,16 @@ package dl
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/yourusername/videostreamingplatform/metadataservice/models"
 )
+
+// ErrVideoNotFound is returned when a video lookup yields no row.
+var ErrVideoNotFound = errors.New("video not found")
 
 // VideoStore defines the database operations required by VideoRepository.
 type VideoStore interface {
@@ -68,7 +72,7 @@ func (r *VideoRepository) GetVideo(ctx context.Context, id string) (*models.Vide
 	}
 
 	if dbVideo == nil {
-		return nil, fmt.Errorf("video not found: %s", id)
+		return nil, fmt.Errorf("%w: %s", ErrVideoNotFound, id)
 	}
 
 	return &models.Video{

--- a/metadataservice/handlers/video.go
+++ b/metadataservice/handlers/video.go
@@ -3,13 +3,30 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strconv"
 	"strings"
 
 	"github.com/yourusername/videostreamingplatform/metadataservice/bl"
+	"github.com/yourusername/videostreamingplatform/metadataservice/dl"
 	"github.com/yourusername/videostreamingplatform/metadataservice/models"
 )
+
+// statusForServiceError maps known service-layer errors to HTTP status codes.
+// Validation errors map to 400, not-found to 404, anything else to 500.
+func statusForServiceError(err error) int {
+	switch {
+	case errors.Is(err, bl.ErrInvalidTitle),
+		errors.Is(err, bl.ErrInvalidSize),
+		errors.Is(err, bl.ErrInvalidVideoID):
+		return http.StatusBadRequest
+	case errors.Is(err, dl.ErrVideoNotFound):
+		return http.StatusNotFound
+	default:
+		return http.StatusInternalServerError
+	}
+}
 
 // VideoHandler handles HTTP requests for video operations
 type VideoHandler struct {
@@ -54,7 +71,7 @@ func (h *VideoHandler) CreateVideo(w http.ResponseWriter, r *http.Request) {
 
 	video, err := h.service.CreateVideo(r.Context(), &req)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		http.Error(w, err.Error(), statusForServiceError(err))
 		return
 	}
 
@@ -78,7 +95,7 @@ func (h *VideoHandler) GetVideo(w http.ResponseWriter, r *http.Request) {
 
 	video, err := h.service.GetVideo(r.Context(), id)
 	if err != nil {
-		http.Error(w, "Video not found", http.StatusNotFound)
+		http.Error(w, err.Error(), statusForServiceError(err))
 		return
 	}
 
@@ -110,7 +127,7 @@ func (h *VideoHandler) UpdateVideo(w http.ResponseWriter, r *http.Request) {
 
 	video, err := h.service.UpdateVideo(r.Context(), id, &req)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		http.Error(w, err.Error(), statusForServiceError(err))
 		return
 	}
 
@@ -131,7 +148,7 @@ func (h *VideoHandler) DeleteVideo(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 
 	if err := h.service.DeleteVideo(r.Context(), id); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		http.Error(w, err.Error(), statusForServiceError(err))
 		return
 	}
 


### PR DESCRIPTION
## Summary
- Validation errors (`ErrInvalidTitle`, `ErrInvalidSize`, `ErrInvalidVideoID`) → **400** (was 500).
- Not-found errors propagate through a new `dl.ErrVideoNotFound` sentinel and return **404** from `GetVideo` / `UpdateVideo` / `DeleteVideo` (was 500 for `UpdateVideo`).
- Single mapping helper `statusForServiceError(err)` in `metadataservice/handlers/video.go` keeps each handler one-line.

## Failing e2e tests this fixes (resiliency suite, run against EKS dev)
- `TestCreateVideo_MissingTitle_Returns400` — was 500, now 400
- `TestUpdateVideo_NotFound_Returns404` — was 500, now 404

## Test plan
- [x] `go build ./...`
- [x] `go vet ./metadataservice/...`
- [x] `go test ./metadataservice/...`
- [ ] Re-run e2e resiliency suite against deployed image once CI builds + deploy run for this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)