### PR TITLE
Return 404 from data-service download on S3 NoSuchKey

### DIFF
--- a/dataservice/handlers/upload.go
+++ b/dataservice/handlers/upload.go
@@ -4,6 +4,7 @@ package handlers
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -176,6 +177,10 @@ func (h *UploadHandler) Download(w http.ResponseWriter, r *http.Request) {
 
 	obj, err := h.storage.Download(r.Context(), key, rangeHeader)
 	if err != nil {
+		if errors.Is(err, storage.ErrObjectNotFound) {
+			http.Error(w, "Video not found", http.StatusNotFound)
+			return
+		}
 		http.Error(w, "Failed to download file", http.StatusInternalServerError)
 		return
 	}

--- a/dataservice/storage/s3.go
+++ b/dataservice/storage/s3.go
@@ -2,13 +2,19 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 )
+
+// ErrObjectNotFound is returned when a Download targets a key that does not
+// exist in the bucket. Handlers map this to 404.
+var ErrObjectNotFound = errors.New("object not found")
 
 type S3Client struct {
 	client *s3.Client
@@ -73,6 +79,10 @@ func (s *S3Client) Download(ctx context.Context, key, rangeHeader string) (*Obje
 	}
 	result, err := s.client.GetObject(ctx, in)
 	if err != nil {
+		var nsk *s3types.NoSuchKey
+		if errors.As(err, &nsk) {
+			return nil, fmt.Errorf("%w: %s", ErrObjectNotFound, key)
+		}
 		return nil, err
 	}
 	obj := &Object{Body: result.Body}


### PR DESCRIPTION
## Summary
Fixes `TestDownload_NonExistentVideo_Returns404` in the e2e happypath suite.

- `dataservice/storage/s3.go`: new `ErrObjectNotFound` sentinel; `Download()` detects `*s3types.NoSuchKey` via `errors.As` and wraps with `%w`.
- `dataservice/handlers/upload.go`: `Download` checks `errors.Is(err, storage.ErrObjectNotFound)` and returns **404** (was a catch-all 500 for any storage error).

Infra/analytics/recommendations deploy work moved to a separate PR in `videostreamingplatform-infra` — that's where infra GitHub Actions belong.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./dataservice/...`
- [ ] After next deploy, re-run e2e happy-path; expect `TestDownload_NonExistentVideo_Returns404` to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)